### PR TITLE
Fix to work when wordpress installed in its own subdirectory

### DIFF
--- a/src/language-redirect.php
+++ b/src/language-redirect.php
@@ -51,7 +51,7 @@ function language_redirect_plugins_loaded() {
 		return;
 	}
 	if ( $redirect_location[0] == '/' ) {
-		header( 'Location: ' . site_url( $redirect_location ) );
+		header( 'Location: ' . home_url( $redirect_location ) );
 	} else {
 		header( 'Location: ' . $redirect_location );
 	}


### PR DESCRIPTION
Function site_url doesn't work when WP is installed in a subdirectory.